### PR TITLE
rajout de count-leaves

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "prepublish": "npm run build && npm run generate-json",
     "build": "tsc --declaration",
     "generate-json": "node src/client/anomaly/script/generate-json-files.js",
+    "count-leaves": "node src/client/anomaly/script/count-leaves.js",
     "format": "npx prettier --write ."
   },
   "dependencies": {

--- a/src/client/anomaly/script/count-leaves.js
+++ b/src/client/anomaly/script/count-leaves.js
@@ -1,0 +1,66 @@
+let anomalies;
+try {
+    anomalies = require('../yml/anomalies.json');
+} catch (error) {
+    console.error("Merci de générer le fichier anomalies.json au préalable.");
+    process.exit();
+}
+
+function countLeavesInSubcategory(sub, tag, hasTagInPath) {
+  if (tag && sub.hasOwnProperty('tags') && sub.tags.includes(tag)) {
+    hasTagInPath = true;
+  }
+
+  if (sub.hasOwnProperty('subcategories')) {
+    return sub.subcategories.reduce(
+      (counter, currentSubcategory) =>
+        counter +
+        countLeavesInSubcategory(currentSubcategory, tag, hasTagInPath),
+      0
+    );
+  } else {
+    if (!tag || (tag && hasTagInPath)) {
+      return 1;
+    } else {
+      return 0;
+    }
+  }
+}
+
+function countLeavesInCategory(category, tag) {
+  if (!category.hasOwnProperty('subcategories')) {
+    return 0;
+  }
+
+  return category.subcategories.reduce(
+    (counter, currentSubcategory) =>
+      counter + countLeavesInSubcategory(currentSubcategory, tag),
+    0
+  );
+}
+
+function countLeavesInCategoriesList(categoriesList, tag) {
+  return categoriesList.reduce(
+    (counter, currentCategory) =>
+      counter + countLeavesInCategory(currentCategory, tag),
+    0
+  );
+}
+
+function getTagFromCmdLineArgument() {
+    return process.argv[2];
+}
+
+console.log(
+  `Nombre total de feuilles: ${countLeavesInCategoriesList(anomalies.list)}`
+);
+
+const tag = getTagFromCmdLineArgument();
+if (tag) {
+    console.log(
+        `Nombre de feuilles avec tag "${tag}" dans chemin: ${countLeavesInCategoriesList(
+          anomalies.list,
+          tag
+        )}`
+      );
+}


### PR DESCRIPTION
Hello @alexandreannic,

J'ai rajouté mon script `count-leaves.js` dans le dossier `src\client\anomaly\script`, le même que celui du script `generate-json-files.js`.

Pour lancer le script, il suffit de rentrer : `npm run count-leaves`.
Ce qui te sort le nombre total de feuilles dans la console : 

```
Nombre total de feuilles: 1276
```

Tu peux aussi rajouter un tag optionnel : `npm run count-leaves "Litige contractuel"`.
Et tu obtiens le nombre total de feuilles + le nombre de feuilles contenant ce tag dans le chemin :  

```
Nombre total de feuilles: 1276
Nombre de feuilles avec tag "Litige contractuel" dans chemin: 290
```

J'imagine que tu as un usage particulier en tête pour ce script, donc à adapter à ton besoin bien sûr.

J'espère que ça te sera utile.

Samuel